### PR TITLE
Update youtube-dl dependency for YT8M_downloader

### DIFF
--- a/YT8M_downloader/requirements.txt
+++ b/YT8M_downloader/requirements.txt
@@ -1,3 +1,3 @@
-youtube-dl==2019.4.7
+youtube-dl==2019.4.24
 tensorflow==1.13.1
 pandas==0.24.2


### PR DESCRIPTION
I ran into this [issue](https://github.com/ytdl-org/youtube-dl/issues/20758) after running `pip install -r requirements.txt` in the `YT8M_downloader` directory and then running the download script. The issue seems to be fixed by updating to the most recent version of `youtube-dl`.