### PR TITLE
Build API & CLI Docker images from base verifier image

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM verifier-api:v1
+FROM verifier:v1
 COPY /api /scripts
 ENTRYPOINT ["python"]
 CMD ["scripts/api.py"]

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,4 +1,4 @@
-FROM verifier-cli:v1
+FROM verifier:v1
 RUN echo "'Copying CLI\n'"
 COPY /cli /scripts
 CMD /bin/bash

--- a/launch_api.sh
+++ b/launch_api.sh
@@ -1,1 +1,1 @@
-docker build -f Dockerfile-api -t verifier-api:v1 . && docker run --volume="$(pwd)/stream":/stream -p 5000:5000 verifier-api:v1
+docker build -f Dockerfile -t verifier:v1 . && docker build -f Dockerfile-api -t verifier-api:v1 . && docker run --volume="$(pwd)/stream":/stream -p 5000:5000 verifier-api:v1

--- a/launch_cli.sh
+++ b/launch_cli.sh
@@ -1,1 +1,1 @@
-docker build -f Dockerfile-cli -t verifier-cli:v1 . && docker run --rm -it --volume="$(pwd)/stream":/stream --ipc=host verifier-cli:v1
+docker build -f Dockerfile -t verifier:v1 . && docker build -f Dockerfile-cli -t verifier-cli:v1 . && docker run --rm -it --volume="$(pwd)/stream":/stream --ipc=host verifier-cli:v1


### PR DESCRIPTION
This PR updates `Dockerfile-api` and `Dockerfile-cli` to use the `verifier:v1` image as a base (which is built from `Dockerfile`). Additionally, the `launch_api.sh` and `launch_cli.sh` scripts have been updated to ensure that the `verifier:v1` image is built locally before trying to build the `verifier-api:v1` and `verifier-cli:v1` images.

Fixes #44 