### PR TITLE
api: Return json response

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,6 +1,6 @@
 # Minimal app for serving Livepeer verification
 from verifier import verify, retrieve_model
-from flask import Flask, request
+from flask import Flask, request, jsonify
 
 import logging
 logging.basicConfig(level=logging.DEBUG)
@@ -27,7 +27,7 @@ def post_route():
         for rendition in data['renditions']:
             results.append({rendition['uri'] : predictions[i]})
             i += 1
-        return 'Results: {}\n'.format(results)
+        return jsonify(results)
   
 
 if __name__ == '__main__':

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -139,7 +139,7 @@ def verify(source_uri, renditions, do_profiling, max_samples, model_dir, model_n
     # Add predictions to rendition dictionary
     for i, rendition in enumerate(renditions):
         rendition.pop('path', None)
-        rendition['tamper'] = y_pred[i]
+        rendition['tamper'] = int(y_pred[i])
 
     if do_profiling:
         print('Features used:', features)


### PR DESCRIPTION
Modified the API to return a JSON response instead of a Python result object.

Had to convert the `tamper` field to a Python int. Otherwise, I was getting a serialization error:

```
  File "/usr/local/lib/python3.6/json/encoder.py", line 428, in _iterencode
    yield from _iterencode_list(o, _current_indent_level)
  File "/usr/local/lib/python3.6/json/encoder.py", line 325, in _iterencode_list
    yield from chunks
  File "/usr/local/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/local/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/local/lib/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/usr/local/lib/python3.6/site-packages/flask/json/__init__.py", line 100, in default
    return _json.JSONEncoder.default(self, o)
  File "/usr/local/lib/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'int64' is not JSON serializable
```