### PR TITLE
readme: Fix typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Further information about this notebooks can be found [here](data-analysis/READM
 
 # 3. Interfaces: CLI and API
 
-Once models are trained and available, a [CLI](https://github.com/livepeer/verification-classifier/tree/master/api) and a [RESTful API](https://github.com/livepeer/verification-classifier/tree/master/cli) to interact with them and obtain predictions are made available.
+Once models are trained and available, a [CLI](https://github.com/livepeer/verification-classifier/tree/master/cli) and a [RESTful API](https://github.com/livepeer/verification-classifier/tree/master/api) to interact with them and obtain predictions are made available.
 The bash scripts launch_cli.sh and launch_api.sh can be run from the root folder of the project.
 
 # 4. Common usage scripts: scripts

--- a/api/README.md
+++ b/api/README.md
@@ -66,7 +66,7 @@ A sample call to the API is provided below:
 
                                 "orchestratorID": "foo",
 
-                                model": "https://storage.googleapis.com/verification-models/verification.tar.xz"}'
+                                "model": "https://storage.googleapis.com/verification-models/verification.tar.xz"}'
 
                                 -H 'Content-Type: application/json'
 


### PR DESCRIPTION
Minor typo fixes to the readmes.

Note that I was unable to get the API request to work by copy-pasting the provided curl command. What worked for me was putting the JSON into a separate file, eg `req.json` and running this command: `curl  --data "@req.json" -H 'Content-Type: application/json' localhost:5000/verify`