### PR TITLE
Response format tweaks

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -80,17 +80,12 @@ A sample call to the API is provided below:
 {"orchestrator_id":"foo",
 "results":[
     {
-        "https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4":
-        {
-            "available":true,
+            "video_available":true,
             "tamper":-1.195989,
             "uri":"https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4"
-        }
     },
     {
-        "https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4":
-        {
-            "available":true,
+            "video_available":true,
             "frame_rate":false,
             "pixels":"1034500",
             "pixels_post_verification":0.09354202835648148,
@@ -106,7 +101,6 @@ A sample call to the API is provided below:
             },
             "tamper":1.219913,
             "uri":"https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4"
-        }
     }],
     "source":"https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4"}
 
@@ -145,17 +139,12 @@ curl localhost:5000/verify -d '{
 "results":
 [
     {
-        "stream/144p_black_and_white/1HWSFYQXa1Q.mp4":
-        {
-            "available":true,
+            "video_available":true,
             "tamper":-9.408425,
             "uri":"stream/144p_black_and_white/1HWSFYQXa1Q.mp4"
-        }
     },
     {
-        "stream/144p/1HWSFYQXa1Q.mp4":
-        {
-            "available":true,
+            "video_available":true,
             "frame_rate":false,
             "pixels":"1034500",
             "pixels_post_verification":0.09354202835648148,
@@ -171,7 +160,6 @@ curl localhost:5000/verify -d '{
             },
             "tamper":1.200134,
             "uri":"stream/144p/1HWSFYQXa1Q.mp4"
-        }
     }
 ],
 "source":"stream/sources/1HWSFYQXa1Q.mp4"}

--- a/api/api.py
+++ b/api/api.py
@@ -68,8 +68,6 @@ def post_route():
      "source": The URI of the video source
      "results": A list with the verification results, with the following:
         {
-            "https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4":
-            {
                 "frame_rate": The ratio between the expected frame rate and the one extracted
                              with OpenCv's backend (GStreamer by default)
                 "pixels": The number of expected total pixels (height x width x number of frames)
@@ -96,7 +94,6 @@ def post_route():
                 "tamper": A float representing a distance to a decision function defined by the
                           pre-trained model fo verification
                 "uri": The URI of the rendition
-        }
      }
     """
     if request.method == 'POST':
@@ -132,7 +129,7 @@ def post_route():
         results = []
         i = 0
         for rendition in data['renditions']:
-            results.append({rendition['uri']: predictions[i]})
+            results.append(predictions[i])
             i += 1
 
         # Append the results to the verification object

--- a/verifier/verifier.py
+++ b/verifier/verifier.py
@@ -43,9 +43,11 @@ def pre_verify(source, rendition):
             try:
                 # Compute the Euclidean distance between source's and rendition's signals
                 rendition['audio_dist'] = np.linalg.norm(source_file_series-rendition_file_series)
-                # Cleanup the audio file generated to avoid cluttering
             except:
-                rendition['audio_dist'] = 'dist_error'
+                # Set to negative to indicate an error during audio comparison
+                # (matching floating-point datatype of Euclidean distance)
+                rendition['audio_dist'] = -1.0
+            # Cleanup the audio file generated to avoid cluttering
             os.remove(audio_file)
 
         rendition_capture = cv2.VideoCapture(video_file)


### PR DESCRIPTION
6973036 api: Remove URL as map key from response object. …

The dynamic URL key made it harder to define a schema for automatic
deserialization.

The `uri` field within each result is still present to identify the
corresponding segment.

f9929de verifier: Signal audio check failure using -1.0. …

Using the same data type as for the success case makes the field
simpler to handle in schema driven deserialization and subsequent
handling.
