### PR TITLE
ci: Add GH action for building/pushing API Docker image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,23 @@
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build and push latest verifier Docker image
+      uses: docker/build-push-action@v1.1.0
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: livepeer/verifier
+        tags: latest
+        cache_froms: livepeer/verifier:latest
+    - name: Build and push verifier-api Docker image
+      uses: docker/build-push-action@v1.1.0
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: livepeer/verifier-api
+        dockerfile: Dockerfile-api
+        tag_with_ref: true

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM verifier:v1
+FROM livepeer/verifier:latest
 COPY /api ./scripts
 ENTRYPOINT ["python"]
 CMD ["scripts/api.py"]

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,4 +1,4 @@
-FROM verifier:v1
+FROM livepeer/verifier:latest
 RUN echo "'Copying CLI\n'"
 COPY /cli /scripts
 CMD /bin/bash

--- a/YT8M_downloader/requirements.txt
+++ b/YT8M_downloader/requirements.txt
@@ -1,3 +1,3 @@
-youtube-dl==2019.4.24
+youtube-dl==2020.5.8
 tensorflow==1.15.2
 pandas==0.24.2

--- a/cli/README.md
+++ b/cli/README.md
@@ -34,7 +34,7 @@ It is possible to do profiling of the processes involved in the computation of t
 The profiling tool [py-spy](https://github.com/benfred/py-spy) has been included in the requirements.txt file and installed within the docker container. Access to the SYS_PTRACE variable needs to be granted when running it, though:
 
 ```
-docker run --rm -f Dockerfile-cli -it --volume="$(pwd)/stream":/stream --ipc=host --cap-add SYS_PTRACE verifier-cli:v1
+docker run --rm -f Dockerfile-cli -it --volume="$(pwd)/stream":/stream --ipc=host --cap-add SYS_PTRACE livepeer/verifier-cli:latest
 ```
 
 Then, simply add the py-spy command to run over the python script:

--- a/launch_api.sh
+++ b/launch_api.sh
@@ -1,1 +1,1 @@
-docker build -f Dockerfile -t verifier:v1 . && docker build -f Dockerfile-api -t verifier-api:v1 . && docker run --volume="$(pwd)/stream":/stream --volume="$(pwd)/logs":/logs -p 5000:5000 verifier-api:v1
+docker build -f Dockerfile -t livepeer/verifier:latest . && docker build -f Dockerfile-api -t livepeer/verifier-api:latest . && docker run --volume="$(pwd)/stream":/stream --volume="$(pwd)/logs":/logs -p 5000:5000 livepeer/verifier-api:latest

--- a/launch_cli.sh
+++ b/launch_cli.sh
@@ -1,1 +1,1 @@
-docker build -f Dockerfile -t verifier:v1 . && docker build -f Dockerfile-cli -t verifier-cli:v1 . && docker run --rm -it --volume="$(pwd)/stream":/stream --ipc=host verifier-cli:v1
+docker build -f Dockerfile -t livepeer/verifier:latest . && docker build -f Dockerfile-cli -t livepeer/verifier-cli:latest . && docker run --rm -it --volume="$(pwd)/stream":/stream --ipc=host livepeer/verifier-cli:latest


### PR DESCRIPTION
Changes in this PR:

- Add a GH action that automatically builds and pushes the `livepeer/verifier` and `livepeer/verifier-api` images to the Livepeer [DockerHub](https://hub.docker.com/u/livepeer) every time a new commit is pushed to the repo allowing the images to be directly pulled from the registry without having to build them locally.
    - The `latest` tag is used for the `livepeer/verifier` image
    - The branch name (with some symbol substitution required for Docker tag names) is used for the `livepeer/verifier-api` image

- Updates all references to image names in the repo to follow the `<REPO_NAME>/<IMAGE_NAME>` convention.

Fixes #92 