### PR TITLE
Docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,69 @@ The mission consists on developing a verification classifier that will give a pa
 
 A series of articles on the topic can be found [here](https://medium.com/@epiclabs.io/assessing-metrics-for-video-quality-verification-in-livepeers-ecosystem-f66f724b2aea) and [here](https://medium.com/@epiclabs.io/assessing-metrics-for-video-quality-verification-in-livepeers-ecosystem-ii-6827d093a380).
 
-This folder contains a Dockerfile to enable the interaction with a CLI for computing an asset's renditions Euclidean distance values.
-Further insight about how this works can be gained by interacting with the [feature_engineering](feature_engineering) section and reading the aforementioned publications. 
-Full documentation on the cli can be found on the cli folder of this repo [here](cli/README.md).
+An up-to-date verifier implementation is exposed through the [API](api/README.md). The implementation section below documents its design. 
 
-This repo contains several folders to separate different steps of the data generation and analysis.
+# Implementation
+This section is intended to give readers a high level understanding of currently implemented verification process, without diving into too much details.
+## Interface
+REST API is the main interface for video verification. It is implemented with Flask and runs on a Gunicorn server inside Docker container. The API is documented [here](api/README.md). 
+## Verification process
+Verification process consist of following steps:
+### 1. Preparation
+Source video and each rendition video are made accessible through file system.
+### 2. Pre-verification
+Metadata attributes, such as width, height and framerate, are read from video file headers and compared among source video, renditions and assumed values passed in the API call. Handled by [Verifier](verifier/verifier.py) class.
+### 3. Frame matching
+The frame matching algorithm goal is to choose closest (by presentation time stamp) frames from source and rendition videos. Once PTS is extracted, the task is trivial, if source and rendition FPS are same. If frame rates doesn't match, the algorithm works as follows: 
+1. An excessive number of frames is picked from source video
+2. Presentation timestamps of rendition video frames are iterated to find closest matching frame for each master frame.
+3. Preset number of best matching frame pairs is picked for further processing.  
 
-# 1. Bulk video data generation: YT8M_Downloader
+Implemented in [VideoAssetProcessor](scripts/asset_processor/video_asset_processor.py) class. 
+### 4. Metrics computation
+On a rendition video level, following numerical metrics are computed:
+- size_dimension_ratio  
+
+For each frame pair, following numerical metrics are computed:
+- temporal_dct
+- temporal_gaussian_mse
+- temporal_gaussian_difference
+- temporal_threshold_gaussian_difference
+- temporal_histogram_distance
+
+One important thing to note regarding frame-level metrics, is that all of them, except temporal_histogram_difference, are applied to V channel of HSV-converted frame image. Without full-channel metrics, it would be trivial for an attacker to craft a very obviously tampered video, which would pass the verification.
+     
+The code for metric computation is located [here](scripts/asset_processor/video_metrics.py).
+### 5. Metrics aggregation
+Each per-frame pair metric is aggregated across frame pairs to get a single value for source-rendition pair in question. Currently, the aggregation function is a simple mean for each metric.
+### 6. Metrics scaling
+The final step is to scale metrics according to video resolution. After that, we have features which could be used with models.
+### 7. Classification
+Once features are extracted for select source-rendition video pair, they are fed to following models:
+- One Class Support Vector Machine  
+This is an anomaly detection model, it was fit to untampered renditions to learn the 'normal' distribution of features and detect outliers. It is characterized by lower number of False Positives, but is somewhat less sensitive to tampered videos. Being unsupervised model, it is expected to generalize well on novel data.
+- CatBoost binary classifier.  
+This supervised model is trained on a labeled dataset and typically achieve higher accuracy, than OCSVM model.
+### 8. Meta-model application
+To make a final prediction, the following rule is applied to classification models output:
+- if OCSVM prediction is "Untampered", return "Untampered"
+- otherwise, return CatBoost model prediction
+
+The goal is to reduce the number of False Positives (tamper) to prevent wrongfully penalizing transcoder nodes. OCSVM model is expected to have higher precision (low FP) on novel data. If OCSVM predicts the observation is an inlier (not tampered), we'll go with it, otherwise we'll use supervised model output. 
+
+# Repository structure
+## 1. Bulk video data generation: YT8M_Downloader
 
 We are using 10 second chunks of videos from the YouTube-8M Dataset available [here](https://research.google.com/youtube8m/).
 Previous work with this dataset can be found [here](https://github.com/epiclabs-io/YT8M).
 
 All the information and the scripts to create the assets reside inside the [YT8M_downloader](YTM8_downloader) folder and are explained in [this](YT8M_downloader/README.md) document.
 
-# 2. Video data analysis: data_analytics
+## 2. Video data analysis: data_analytics
 
 From the raw video dataset created we obtain different features out of the analysis made with different tools.
 
-## 2.1. Generation of renditions
+### 2.1. Generation of renditions
 As part of the feature extraction, we want to generate different variations of the videos including different renditions, flipped videos, etc. Some of these variations constitute the bulk of what we label as "attacks". Other constitute "good" renditions where no distortions are included.
 
 To obtain the different "attacks", we provide several scripts in order to perform each variation.
@@ -33,7 +78,7 @@ All the information and the scripts can be found inside the scripts folder [here
 Section 1 of [Tools.ipynb](feature_engineering/notebooks/Tools.ipynb) notebook helps in the usage in case a notebook is preferred as a means of interaction.
 
 
-# 2.2. Metrics computation with external tools
+### 2.2. Metrics computation with external tools
 
 There are different standard metrics (VMAF, MS-SSIM, SSIM and PSNR) provided by external tools (ffmpeg and libav) which can be run from the data-analysis/notebooks folder Tools.ipynb notebook. The notebook provides info on how to use them, but also inside the scripts folder [here](/scripts/README.md)
 
@@ -41,22 +86,22 @@ Section 2 of [Tools.ipynb](feature_engineering/notebooks/Tools.ipynb) notebook h
 
 Alternatively, the scripts can be run separately as bash scripts.
 
-# 2.3. Data analysis with jupyter notebooks
+### 2.3. Data analysis with jupyter notebooks
 
 At this step we should have the required data in the form of video assets and attacks as well as the metrics extracted with the external tools which may be required by some of the notebooks.
 
 Further information about this notebooks can be found [here](feature_engineering/README.md)
 
-# 3. Interfaces: CLI and API
+## 3. Interfaces: CLI and API
 
 Once models are trained and available, a [CLI](https://github.com/livepeer/verification-classifier/tree/master/cli) and a [RESTful API](https://github.com/livepeer/verification-classifier/tree/master/api) to interact with them and obtain predictions are made available.
 The bash scripts launch_cli.sh and launch_api.sh can be run from the root folder of the project.
 
-# 4. Common usage scripts: scripts
+## 4. Common usage scripts: scripts
 
 Several utility scripts are hosted in this folder for convenience. They are needed at different stages of the process and for different Docker instances.
 
-# 5. Unit Tests
+## 5. Unit Tests
 
 Unit tests are located in testing/tests folder. Some tests are using data included in repository (under testing/tests/data, machine_learning/output/models, etc.), while other require the following assets to be downloaded and extracted into ../data directory:
 1. [Dataset CSV](https://storage.cloud.google.com/feature_dataset/yt8m-large.tar.gz)

--- a/api/README.md
+++ b/api/README.md
@@ -11,50 +11,52 @@ The verifier API exposes video verification capabilities through HTTP REST endpo
 **Description:**  
 This function performs verification of renditions of source video. There are two use cases:  
 1. video files are accessible to the server
-            - content-type of the request should be application/json
+
+    - content-type of the request should be application/json
 2. video files are passed in request body (like a browser)
-            - content-type of the request should be multipart/form-data
-            - parameters should be passed as JSON in form's single 'json' field
-            - files should be passed as multipart data, there should be correspondence between 'source, 'uri' fields in parameters and file names. Name fields of files should be unique.  
+
+    - content-type of the request should be multipart/form-data
+    - parameters should be passed as JSON in form's single 'json' field
+    - files should be passed as multipart data, there should be correspondence between 'source', 'uri' fields in parameters and file names. Name fields of files should be unique.  
             
 **Parameters:**  
-``` {
-"orchestrator_id": The ID of the orchestrator responsible of transcoding  
-"source": a URI or name of the source video    
-"renditions": a list of renditions with the following structure:  
-    [{
-         "uri": a name or URI of rendition,
-         "resolution":{
-            "height": integer, vertical dimension, in pixels
-            "width": integer, horizontal dimension, in pixels
-         },
-         "frame_rate": float, expected FPS, with a special value of 0, which means 'same as source video' 
-         "pixels": integer, The number of expected total pixels
-                   (height x width x number of frames)
-    }] 
+```
+{
+  "orchestrator_id": "string, the ID of the orchestrator responsible of transcoding",
+  "source": "string, an URI or name of the source video",
+  "renditions": [
+    {
+      "uri": "string, a name or URI of rendition",
+      "resolution": {
+        "height": "integer, vertical dimension, in pixels",
+        "width": "integer, horizontal dimension, in pixels"
+      },
+      "frame_rate": "float, expected FPS, with a special value of 0, which means 'same as source video'",
+      "pixels": "integer, The number of expected total pixels (height x width x number of frames)"
+    }
+  ]
 }
 ```
 **Returns:**
 ```
 {
-  "orchestrator_id": The ID of the orchestrator responsible of transcoding ,
-   "results":[      {
-         "audio_available": boolean, whether file contained audio stream,
-         "fps": actual rendition framerate,
-         "width": rendition frame width,         
-         "height": rendition frame height,
-         "ocsvm_dist": distance to separating plane of OCSVM classifier for this rendition, negative value represents an outlier (tampered rendition),
-         "tamper": binary classification result, 1 if rendition predicted to be tampered, 0 otherwise
-         "tamper_sl": binary classification result from supervised CatBoost model,
-         "tamper_ul": binary classification result from unsupervised OCSVM anomaly detector,
-         "uri": rendition URI,
-         "video_available": boolean, whether file contained a video stream,
-         
-      
-}
-    ],
-       "source": source video URI 
+  "orchestrator_id": "string, The ID of the orchestrator responsible of transcoding",
+  "results": [
+    {
+      "audio_available": "boolean, whether file contained audio stream",
+      "fps": "float, actual rendition framerate",
+      "width": "integer, rendition frame width",
+      "height": "integer, rendition frame height",
+      "ocsvm_dist": "float, distance to separating plane of OCSVM classifier for this rendition, negative value represents an outlier (tampered rendition)",
+      "tamper": "integer, 0 or 1, binary classification result, 1 if rendition predicted to be tampered, 0 otherwise",
+      "tamper_sl": "integer, 0 or 1, binary classification result from supervised CatBoost model",
+      "tamper_ul": "integer, 0 or 1, binary classification result from unsupervised OCSVM anomaly detector",
+      "uri": "string, rendition URI",
+      "video_available": "boolean, whether file contained a video stream"
     }
+  ],
+  "source": "string, source video URI"
+}
 ``` 
 
 ## Running a docker image
@@ -77,8 +79,8 @@ A sample call to the API is provided below:
 
 ```
 
- curl localhost:5000/verify -d '{"source": "https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4",
-
+ curl localhost:5000/verify -d '{
+                                "source": "https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4",
                                 "renditions": [
                                                 {
                                                     "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4"
@@ -92,7 +94,8 @@ A sample call to the API is provided below:
                                                     "pixels":"1034500"
                                                 }
                                             ],
-                                "orchestratorID": "foo"}' -H 'Content-Type: application/json'
+                                "orchestratorID": "foo"
+                                }' -H 'Content-Type: application/json'
 ```
 
 *Response (remote assets)*
@@ -148,52 +151,52 @@ curl localhost:5000/verify -d '{
             "pixels":"1034500"
         }
         ],
-        "orchestratorID": "foo"}' -H 'Content-Type: application/json'
+        "orchestratorID": "foo"
+        }' -H 'Content-Type: application/json'
 
 ```
 
 *Response (local assets)*
 ```
-
 {
-"model":"https://storage.googleapis.com/verification-models/verification.tar.xz",
-"orchestrator_id":"foo",
-"results":
-[
+  "model": "https://storage.googleapis.com/verification-models/verification.tar.xz",
+  "orchestrator_id": "foo",
+  "results": [
     {
-    "audio_available":false,
-    "ocsvm_dist":-0.04083180936940067,
-    "ssim_pred":0.6080637397913853,
-    "tamper_meta":-1,
-    "tamper_sl":-1,
-    "tamper_ul":-1,
-    "uri":"stream/144p_black_and_white/1HWSFYQXa1Q.mp4","video_available":true
+      "audio_available": false,
+      "ocsvm_dist": -0.04083180936940067,
+      "ssim_pred": 0.6080637397913853,
+      "tamper_meta": -1,
+      "tamper_sl": -1,
+      "tamper_ul": -1,
+      "uri": "stream/144p_black_and_white/1HWSFYQXa1Q.mp4",
+      "video_available": true
     },
     {
-        "audio_available":false,
-        "frame_rate":false,
-        "ocsvm_dist":0.06808371913784983,
-        "pixels":"1034500",
-        "pixels_post_verification":2.55114622790404,
-        "pixels_pre_verification":127119360.0,
-        "resolution":
-        {
-            "height":"144",
-            "height_post_verification":1.0,
-            "height_pre_verification":1.0,
-            "width":"256",
-            "width_post_verification":1.0,
-            "width_pre_verification":1.0
-        },
-        "ssim_pred":0.6214110237850428,
-        "tamper_meta":-1,
-        "tamper_sl":-1,
-        "tamper_ul":1,
-        "uri":"stream/144p/1HWSFYQXa1Q.mp4",
-        "video_available":true
+      "audio_available": false,
+      "frame_rate": false,
+      "ocsvm_dist": 0.06808371913784983,
+      "pixels": "1034500",
+      "pixels_post_verification": 2.55114622790404,
+      "pixels_pre_verification": 127119360,
+      "resolution": {
+        "height": "144",
+        "height_post_verification": 1,
+        "height_pre_verification": 1,
+        "width": "256",
+        "width_post_verification": 1,
+        "width_pre_verification": 1
+      },
+      "ssim_pred": 0.6214110237850428,
+      "tamper_meta": -1,
+      "tamper_sl": -1,
+      "tamper_ul": 1,
+      "uri": "stream/144p/1HWSFYQXa1Q.mp4",
+      "video_available": true
     }
-],
-"source":"stream/sources/1HWSFYQXa1Q.mp4"}
+  ],
+  "source": "stream/sources/1HWSFYQXa1Q.mp4"
+}
 
 ```
 
@@ -204,37 +207,38 @@ Note:
 - JSON parameters are passed in `json` form field
 - file form fields have unique names (file1, file2) 
 ```
-curl localhost:5000/verify -F 'file1=@../data/renditions/1080p/0fIdY5IAnhY_60.mp4;filename=1080_0fIdY5IAnhY_60.mp4' -F 'file2=@../data/renditions/720p/0fIdY5IAnhY_60.mp4;filename=720_0fIdY5IAnhY_60.mp4' -F 'json={"source": "1080_0fIdY5IAnhY_60.mp4",
-
+curl localhost:5000/verify -F 'file1=@../data/renditions/1080p/0fIdY5IAnhY_60.mp4;filename=1080_0fIdY5IAnhY_60.mp4' \
+                           -F 'file2=@../data/renditions/720p/0fIdY5IAnhY_60.mp4;filename=720_0fIdY5IAnhY_60.mp4' \
+                           -F 'json={
+                                "source": "1080_0fIdY5IAnhY_60.mp4",
                                 "renditions": [
                                                 {
                                                     "uri": "720_0fIdY5IAnhY_60.mp4"
                                                 }
                                             ],
-                                "orchestratorID": "foo"}'
+                                "orchestratorID": "foo"
+                                }'
 ```
 #### Response
 ```
 {
-   "model":"http://storage.googleapis.com/verification-models/verification-metamodel-fps2.tar.xz",
-   "orchestrator_id":"foo",
-   "results":[
-      {
-         "audio_available":false,
-         "fps":60.0,
-         "height":720,
-         "ocsvm_dist":0.028662416537303254,
-         "ssim_pred":0.9728838728836663,
-         "tamper":0,
-         "tamper_sl":0,
-         "tamper_ul":1,
-         "uri":"/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/720_0fIdY5IAnhY_60.mp4",
-         "video_available":true,
-         "width":1280
-      
-}
-   
-],
-   "source":"/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/1080_0fIdY5IAnhY_60.mp4"
+  "model": "http://storage.googleapis.com/verification-models/verification-metamodel-fps2.tar.xz",
+  "orchestrator_id": "foo",
+  "results": [
+    {
+      "audio_available": false,
+      "fps": 60,
+      "height": 720,
+      "ocsvm_dist": 0.028662416537303254,
+      "ssim_pred": 0.9728838728836663,
+      "tamper": 0,
+      "tamper_sl": 0,
+      "tamper_ul": 1,
+      "uri": "/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/720_0fIdY5IAnhY_60.mp4",
+      "video_available": true,
+      "width": 1280
+    }
+  ],
+  "source": "/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/1080_0fIdY5IAnhY_60.mp4"
 }
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -1,44 +1,73 @@
-# REST HTTP API INSTRUCTIONS
+# Verification API
 
-Description of this functionality can be found in [this](https://github.com/livepeer/verification-classifier/issues/40) github issue.
+The verifier API exposes video verification capabilities through HTTP REST endpoints. 
 
-## 1.- Build the image and create a container
+## API endpoints
+### /verify
 
-To build the image and create a container, we have to run the following bash script located in the root of the project:
+#### 
+**Method:** `POST`  
+**Content-type:** `application/json` or `multipart/form-data`  
+**Description:**  
+This function performs verification of renditions of source video. There are two use cases:  
+1. video files are accessible to the server
+            - content-type of the request should be application/json
+2. video files are passed in request body (like a browser)
+            - content-type of the request should be multipart/form-data
+            - parameters should be passed as JSON in form's single 'json' field
+            - files should be passed as multipart data, there should be correspondence between 'source, 'uri' fields in parameters and file names. Name fields of files should be unique.  
+            
+**Parameters:**  
+``` {
+"orchestrator_id": The ID of the orchestrator responsible of transcoding  
+"source": a URI or name of the source video    
+"renditions": a list of renditions with the following structure:  
+    [{
+         "uri": a name or URI of rendition,
+         "resolution":{
+            "height": integer, vertical dimension, in pixels
+            "width": integer, horizontal dimension, in pixels
+         },
+         "frame_rate": float, expected FPS, with a special value of 0, which means 'same as source video' 
+         "pixels": integer, The number of expected total pixels
+                   (height x width x number of frames)
+    }] 
+}
+```
+**Returns:**
+```
+{
+  "orchestrator_id": The ID of the orchestrator responsible of transcoding ,
+   "results":[      {
+         "audio_available": boolean, whether file contained audio stream,
+         "fps": actual rendition framerate,
+         "width": rendition frame width,         
+         "height": rendition frame height,
+         "ocsvm_dist": distance to separating plane of OCSVM classifier for this rendition, negative value represents an outlier (tampered rendition),
+         "tamper": binary classification result, 1 if rendition predicted to be tampered, 0 otherwise
+         "tamper_sl": binary classification result from supervised CatBoost model,
+         "tamper_ul": binary classification result from unsupervised OCSVM anomaly detector,
+         "uri": rendition URI,
+         "video_available": boolean, whether file contained a video stream,
+         
+      
+}
+    ],
+       "source": source video URI 
+    }
+``` 
+
+## Running a docker image
+
+To build the image and create a container, run the following bash script located in the root of the project:
 
 ```
 ./launch_api.sh
 ```
 
-This will create a Docker image based on `python3` and adds the needed python dependencies.
-This image basically wraps a Flask http server around the verifier.py script.
+This will create and run a Docker image with API exposed on the port 5000.
 
-## 2.- Usage
-
-Once the Docker container is running, a Flask HTTP server will made available in the port 5000.
-
-### Parameters
-
-*Object* - The verification request object
-
-    *source*: string - The URI that can be used to download the input segment. The verifier can infer how to download the segment based on the schema of the URI (i.e. download via HTTPS if the URI has a https:// prefix). If the verifier does not support the schema of the URI or if it is missing, the verifier will look for the data locally
-
-    *renditions*: array Rendition - An array of rendition objects that contain rendition URIs that can be used to download the rendition segment data. The rendition URIs are nested in a object to allow for future addition of fields that can indicate expected values for pre-verification checks (i.e. expected bitrate, framerate, resolution, etc.)
-
-### Example Parameters
-
-params: [{
-    "source": "http://127.0.0.1/stream/abcd/5.ts",
-    "renditions": [
-        {"uri": "http://127.0.0.1/stream/abcd/P720p30fps4x3/5.ts"},
-        {"uri": "http://127.0.0.1/stream/abcd/P720p60fps16x9/5.ts"}
-    ],
-    "model": "http://127.0.0.1/model/verification.tar.gz"
-}]
-
-### Returns
-
-An object that indicates whether each rendition passed/failed verification.
+## Examples
 
 ### Example (URI or shared volume path)
 
@@ -186,5 +215,26 @@ curl localhost:5000/verify -F 'file1=@../data/renditions/1080p/0fIdY5IAnhY_60.mp
 ```
 #### Response
 ```
-{"model":"http://storage.googleapis.com/verification-models/verification-metamodel-fps2.tar.xz","orchestrator_id":"foo","results":[{"audio_available":false,"fps":60.0,"height":720,"ocsvm_dist":0.028662416537303254,"ssim_pred":0.9728838728836663,"tamper":0,"tamper_sl":0,"tamper_ul":1,"uri":"/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/720_0fIdY5IAnhY_60.mp4","video_available":true,"width":1280}],"source":"/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/1080_0fIdY5IAnhY_60.mp4"}
+{
+   "model":"http://storage.googleapis.com/verification-models/verification-metamodel-fps2.tar.xz",
+   "orchestrator_id":"foo",
+   "results":[
+      {
+         "audio_available":false,
+         "fps":60.0,
+         "height":720,
+         "ocsvm_dist":0.028662416537303254,
+         "ssim_pred":0.9728838728836663,
+         "tamper":0,
+         "tamper_sl":0,
+         "tamper_ul":1,
+         "uri":"/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/720_0fIdY5IAnhY_60.mp4",
+         "video_available":true,
+         "width":1280
+      
+}
+   
+],
+   "source":"/tmp/d0424e5c79c9401d893d6f2b8e87dfc2/1080_0fIdY5IAnhY_60.mp4"
+}
 ```

--- a/api/README.md
+++ b/api/README.md
@@ -75,88 +75,88 @@ This will create and run a Docker image with API exposed on the port 5000.
 
 A sample call to the API is provided below:
 
-*Request (remote assets)*
+####Request (remote assets)
 
 ```
-
- curl localhost:5000/verify -d '{
-                                "source": "https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4",
-                                "renditions": [
-                                                {
-                                                    "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4"
-                                                },
-                                                {
-                                                    "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4",
-                                                    "resolution":{
-                                                        "height":"144",
-                                                        "width":"256"},
-                                                    "frame_rate": "24",
-                                                    "pixels":"1034500"
-                                                }
-                                            ],
-                                "orchestratorID": "foo"
-                                }' -H 'Content-Type: application/json'
-```
-
-*Response (remote assets)*
-
-```
-
-{"orchestrator_id":"foo",
-"results":[
+curl localhost:5000/verify -d '{
+  "source": "https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4",
+  "renditions": [
     {
-            "video_available":true,
-            "tamper":-1.195989,
-            "uri":"https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4"
+      "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4"
     },
     {
-            "video_available":true,
-            "frame_rate":false,
-            "pixels":"1034500",
-            "pixels_post_verification":0.09354202835648148,
-            "pixels_pre_verification":127119360.0,
-            "resolution":
-            {
-                "height":"144",
-                "height_post_verification":1.0,
-                "height_pre_verification":1.0,
-                "width":"256",
-                "width_post_verification":1.0,
-                "width_pre_verification":1.0
-            },
-            "tamper":1.219913,
-            "uri":"https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4"
-    }],
-    "source":"https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4"}
-
+      "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4",
+      "resolution": {
+        "height": "144",
+        "width": "256"
+      },
+      "frame_rate": "24",
+      "pixels": "1034500"
+    }
+  ],
+  "orchestratorID": "foo"
+}' -H 'Content-Type: application/json'
 ```
 
-*Request (local assets)*
+####Response (remote assets)
+
+```
+{
+  "orchestrator_id": "foo",
+  "results": [
+    {
+      "video_available": true,
+      "tamper": -1.195989,
+      "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p_black_and_white/-3MYFnEaYu4.mp4"
+    },
+    {
+      "video_available": true,
+      "frame_rate": false,
+      "pixels": "1034500",
+      "pixels_post_verification": 0.09354202835648148,
+      "pixels_pre_verification": 127119360,
+      "resolution": {
+        "height": "144",
+        "height_post_verification": 1,
+        "height_pre_verification": 1,
+        "width": "256",
+        "width_post_verification": 1,
+        "width_pre_verification": 1
+      },
+      "tamper": 1.219913,
+      "uri": "https://storage.googleapis.com/livepeer-verifier-renditions/144p/-3MYFnEaYu4.mp4"
+    }
+  ],
+  "source": "https://storage.googleapis.com/livepeer-verifier-renditions/480p/-3MYFnEaYu4.mp4"
+}
+```
+
+####Request (local assets)
 
 ```
 
 curl localhost:5000/verify -d '{
-    "source": "stream/sources/1HWSFYQXa1Q.mp4",
-    "renditions": [
-        {
-            "uri": "stream/144p_black_and_white/1HWSFYQXa1Q.mp4"
-        },
-        {
-            "uri": "stream/144p/1HWSFYQXa1Q.mp4",
-            "resolution":{
-                "height":"144",
-                "width":"256"
-                },
-            "frame_rate": "24",
-            "pixels":"1034500"
-        }
-        ],
-        "orchestratorID": "foo"
-        }' -H 'Content-Type: application/json'
+  "source": "stream/sources/1HWSFYQXa1Q.mp4",
+  "renditions": [
+    {
+      "uri": "stream/144p_black_and_white/1HWSFYQXa1Q.mp4"
+    },
+    {
+      "uri": "stream/144p/1HWSFYQXa1Q.mp4",
+      "resolution": {
+        "height": "144",
+        "width": "256"
+      },
+      "frame_rate": "24",
+      "pixels": "1034500"
+    }
+  ],
+  "orchestratorID": "foo"
+}' -H 'Content-Type: application/json'
 
 ```
 
-*Response (local assets)*
+####Response (local assets)
 ```
 {
   "model": "https://storage.googleapis.com/verification-models/verification.tar.xz",
@@ -197,7 +197,6 @@ curl localhost:5000/verify -d '{
   ],
   "source": "stream/sources/1HWSFYQXa1Q.mp4"
 }
-
 ```
 
 ### Example (upload files in the query)
@@ -210,14 +209,14 @@ Note:
 curl localhost:5000/verify -F 'file1=@../data/renditions/1080p/0fIdY5IAnhY_60.mp4;filename=1080_0fIdY5IAnhY_60.mp4' \
                            -F 'file2=@../data/renditions/720p/0fIdY5IAnhY_60.mp4;filename=720_0fIdY5IAnhY_60.mp4' \
                            -F 'json={
-                                "source": "1080_0fIdY5IAnhY_60.mp4",
-                                "renditions": [
-                                                {
-                                                    "uri": "720_0fIdY5IAnhY_60.mp4"
-                                                }
-                                            ],
-                                "orchestratorID": "foo"
-                                }'
+  "source": "1080_0fIdY5IAnhY_60.mp4",
+  "renditions": [
+    {
+      "uri": "720_0fIdY5IAnhY_60.mp4"
+    }
+  ],
+  "orchestratorID": "foo"
+}'
 ```
 #### Response
 ```

--- a/api/api.py
+++ b/api/api.py
@@ -89,7 +89,7 @@ def post_route():
         2. video files are passed in request body (like a browser)
             - content-type of the request should be multipart/form-data
             - parameters should be passed as JSON in form's single 'json' field
-            - files should be passed as multipart data, there should be correspondence between 'source, 'uri' fields in parameters and file names. Name fields of fields should be unique.
+            - files should be passed as multipart data, there should be correspondence between 'source, 'uri' fields in parameters and file names. Name fields of files should be unique.
     Input parameters:
 
     "orchestrator_id": The ID of the orchestrator responsible of transcoding
@@ -104,8 +104,7 @@ def post_route():
          "frame_rate": A value of the expected frames per seconds
          "pixels": The number of expected total pixels
                    (height x width x number of frames)
-    },
-   "model": The URL to the location of the trained model for verification
+    }
 
     Returns:
 


### PR DESCRIPTION
These docs updates are addressing #122 . The only point not addressed is a channel attack generation script. It was not included in the repo and renditions generated with it weren't added to the dataset, because such an attack is very trivial, if there's any metric which uses all image channels. Instead of that, a specific unit test and a channel-manipulated rendition video were included in the repo, to make sure all all-channel metrics are not accidentally excluded from models.
